### PR TITLE
[feature][refresh_token] implement refresh token and api logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,14 @@
   - [ ] Deploy the application to a cloud provider (e.g., Heroku, AWS, Google Cloud, or Digital Ocean).
 
 Note: The checklist indicates the completion status of each task. Update the checklist as tasks are completed, and consider deploying the application to a cloud provider for production use.
+
+## Feedback
+
+- **Refresh token**
+
+  - [x] endpoint POST api/refresh
+  - [x] endpoint POST api/sign_out
+  - [x] expired time of jwt: 15 mins
+  - [x] expired time of refresh token: 7 days
+  - [x] add refresh token to api/login response and cover with payload: data: {}
+  - [x] add block jwt with sign_out or block request from jwt

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -11,11 +11,13 @@ module Api
 
     def jwt_authenticate!
       header = request.headers['Authorization']
-      payload = JwtService.decode(header.split.last)
-      @current_user = User.find(payload['user_id'])
-    rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError
+      @jwt_token = header.split.last
+      @payload = UserJwtService.decode(@jwt_token)
+      @current_user = User.find(@payload[:user_id])
+    rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError,
+      UserJwtService::JwtTypeError
       render json: { error: 'Invalid token' }, status: :unauthorized
-    rescue StandardError
+    rescue StandardError, UserJwtService::JWTRejectedError
       render json: { error: 'Please Login' }, status: :unauthorized
     end
   end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -14,10 +14,9 @@ module Api
       @jwt_token = header.split.last
       @payload = UserJwtService.decode(@jwt_token)
       @current_user = User.find(@payload[:user_id])
-    rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError,
-      UserJwtService::JwtTypeError
+    rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError, UserJwtService::JwtTypeError
       render json: { error: 'Invalid token' }, status: :unauthorized
-    rescue StandardError, UserJwtService::JWTRejectedError
+    rescue StandardError, UserJwtService::JwtRejectedError
       render json: { error: 'Please Login' }, status: :unauthorized
     end
   end

--- a/app/controllers/api/authentication_controller.rb
+++ b/app/controllers/api/authentication_controller.rb
@@ -1,21 +1,50 @@
 module Api
   class AuthenticationController < Api::ApplicationController
-    skip_before_action :jwt_authenticate!
+    skip_before_action :jwt_authenticate!, only: %i[sign_in refresh]
 
     def sign_in
       user = User.find_by(email: login_params[:email])
 
       if user&.valid_password?(login_params[:password])
-        render json: { token: JwtService.encode({ user_id: user.id }) }
+        render json: {
+          data: {
+            token: UserJwtService.generate_token(user.id),
+            refresh_token: UserJwtService.generate_refresh_token(user.id)
+          }
+        }, status: :ok
       else
         render json: { error: 'Invalid email or password' }, status: :unauthorized
       end
+    end
+
+    def refresh
+      payload = UserJwtService.decode(refresh_params[:refresh_token], type: 'refresh_token')
+      render json: {
+          data: {
+            token: UserJwtService.generate_token(payload[:user_id]),
+            refresh_token: refresh_params[:refresh_token]
+          }
+        }, status: :ok
+    rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError,
+      UserJwtService::JwtTypeError
+      render json: { error: 'Invalid token' }, status: :unauthorized
+    rescue StandardError, UserJwtService::JWTRejectedError
+      render json: { error: 'Please Login' }, status: :unauthorized
+    end
+
+    def sign_out
+      UserJwtService.block(@jwt_token, @payload)
+      render json: { data: { message: 'Logout Success' } }, status: :ok
     end
 
     private
 
     def login_params
       params.require(:authentication).permit(:email, :password)
+    end
+
+    def refresh_params
+      params.require(:authentication).permit(:refresh_token)
     end
   end
 end

--- a/app/controllers/api/authentication_controller.rb
+++ b/app/controllers/api/authentication_controller.rb
@@ -6,12 +6,7 @@ module Api
       user = User.find_by(email: login_params[:email])
 
       if user&.valid_password?(login_params[:password])
-        render json: {
-          data: {
-            token: UserJwtService.generate_token(user.id),
-            refresh_token: UserJwtService.generate_refresh_token(user.id)
-          }
-        }, status: :ok
+        render json: { data: login_response(user.id) }, status: :ok
       else
         render json: { error: 'Invalid email or password' }, status: :unauthorized
       end
@@ -19,16 +14,10 @@ module Api
 
     def refresh
       payload = UserJwtService.decode(refresh_params[:refresh_token], type: 'refresh_token')
-      render json: {
-          data: {
-            token: UserJwtService.generate_token(payload[:user_id]),
-            refresh_token: refresh_params[:refresh_token]
-          }
-        }, status: :ok
-    rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError,
-      UserJwtService::JwtTypeError
+      render json: { data: refresh_response(payload[:user_id]) }, status: :ok
+    rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::VerificationError, UserJwtService::JwtTypeError
       render json: { error: 'Invalid token' }, status: :unauthorized
-    rescue StandardError, UserJwtService::JWTRejectedError
+    rescue StandardError, UserJwtService::JwtRejectedError
       render json: { error: 'Please Login' }, status: :unauthorized
     end
 
@@ -38,6 +27,14 @@ module Api
     end
 
     private
+
+    def login_response(user_id)
+      { token: UserJwtService.generate_token(user_id), refresh_token: UserJwtService.generate_refresh_token(user_id) }
+    end
+
+    def refresh_response(user_id)
+      { token: UserJwtService.generate_token(user_id), refresh_token: refresh_params[:refresh_token] }
+    end
 
     def login_params
       params.require(:authentication).permit(:email, :password)

--- a/app/services/user_jwt_service.rb
+++ b/app/services/user_jwt_service.rb
@@ -9,30 +9,32 @@ class UserJwtService
     JWT_EXPIRATION = 15.minutes
     REFRESH_EXPIRATION = 7.days
 
-    def generate_token user_id, expiration: JWT_EXPIRATION
-      JwtService.encode({user_id: user_id, type: 'token'}, expiration: expiration)
+    def generate_token(user_id, expiration: JWT_EXPIRATION)
+      JwtService.encode({ user_id: user_id, type: 'token' }, expiration: expiration)
     end
 
-    def generate_refresh_token user_id, expiration: REFRESH_EXPIRATION
-      JwtService.encode({user_id: user_id, type: 'refresh_token'}, expiration: expiration)
+    def generate_refresh_token(user_id, expiration: REFRESH_EXPIRATION)
+      JwtService.encode({ user_id: user_id, type: 'refresh_token' }, expiration: expiration)
     end
 
-    def decode token, type: 'token'
+    def decode(token, type: 'token')
       raise JwtRejectedError, 'Token invalid' if redis.get(token)
+
       payload = JwtService.decode(token)
       raise JwtTypeError, 'Token type invalid' if payload[:type] != type
+
       payload
     end
 
-    def block token, payload
+    def block(token, payload)
       ex = payload[:exp] - Time.now.to_i
-      redis.set(token, true, ex: ex) if ex > 0
+      redis.set(token, true, ex: ex) if ex.positive?
     end
 
     private
 
     def redis
-      Redis.new(url: ENV["REDIS_URL"])
+      Redis.new(url: ENV.fetch('REDIS_URL'))
     end
   end
 end

--- a/app/services/user_jwt_service.rb
+++ b/app/services/user_jwt_service.rb
@@ -1,0 +1,38 @@
+class UserJwtService
+  class JwtRejectedError < StandardError
+  end
+
+  class JwtTypeError < StandardError
+  end
+
+  class << self
+    JWT_EXPIRATION = 15.minutes
+    REFRESH_EXPIRATION = 7.days
+
+    def generate_token user_id, expiration: JWT_EXPIRATION
+      JwtService.encode({user_id: user_id, type: 'token'}, expiration: expiration)
+    end
+
+    def generate_refresh_token user_id, expiration: REFRESH_EXPIRATION
+      JwtService.encode({user_id: user_id, type: 'refresh_token'}, expiration: expiration)
+    end
+
+    def decode token, type: 'token'
+      raise JwtRejectedError, 'Token invalid' if redis.get(token)
+      payload = JwtService.decode(token)
+      raise JwtTypeError, 'Token type invalid' if payload[:type] != type
+      payload
+    end
+
+    def block token, payload
+      ex = payload[:exp] - Time.now.to_i
+      redis.set(token, true, ex: ex) if ex > 0
+    end
+
+    private
+
+    def redis
+      Redis.new(url: ENV["REDIS_URL"])
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     post 'sign_in', to: 'authentication#sign_in'
+    post 'refresh', to: 'authentication#refresh'
+    post 'sign_out', to: 'authentication#sign_out'
     namespace :v1 do
       resources :keywords, only: %i[index create show]
     end

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe '/api/sign_in', type: :request do
   let(:valid_params) { { authentication: { email: current_user.email, password: '123456' } } }
   let(:invalid_params) { { authentication: { email: current_user.email, password: '111111' } } }
   let(:token) { UserJwtService.generate_token(current_user.id) }
-  let(:expired_refresh_token) { JwtService.encode( { user_id: current_user.id, exp: 1.hour.ago.to_i } ) }
+  let(:expired_refresh_token) { JwtService.encode({ user_id: current_user.id, exp: 1.hour.ago.to_i }) }
   let(:refresh_token) { UserJwtService.generate_refresh_token(current_user.id) }
   let(:headers) { { Authorization: "Bearer #{token}" } }
 
@@ -32,11 +32,11 @@ RSpec.describe '/api/sign_in', type: :request do
 
   describe 'POST /refresh' do
     context 'with valid refresh_token' do
-      let (:new_token) { UserJwtService.generate_token(current_user.id) }
+      let(:new_token) { UserJwtService.generate_token(current_user.id) }
       it 'renders a successful response' do
-        allow(UserJwtService).to receive(:decode).and_return({user_id: current_user.id, type: 'refesh_token'})
+        allow(UserJwtService).to receive(:decode).and_return({ user_id: current_user.id, type: 'refesh_token' })
         allow(UserJwtService).to receive(:generate_token).and_return(new_token)
-        post '/api/refresh', params: { authentication: {refresh_token: refresh_token}}
+        post '/api/refresh', params: { authentication: { refresh_token: refresh_token } }
         expect(response).to be_successful
         expect(response.parsed_body['data']['token']).to eq(new_token)
         expect(response.parsed_body['data']['refresh_token']).to eq(refresh_token)
@@ -45,7 +45,7 @@ RSpec.describe '/api/sign_in', type: :request do
 
     context 'with expired refresh_token' do
       it 'renders a successful response' do
-        post '/api/refresh', params: { authentication: {refresh_token: expired_refresh_token}}
+        post '/api/refresh', params: { authentication: { refresh_token: expired_refresh_token } }
         expect(response).to have_http_status(:unauthorized)
         expect(response.parsed_body['error']).to eq('Please Login')
       end
@@ -53,17 +53,19 @@ RSpec.describe '/api/sign_in', type: :request do
 
     context 'with blocked refresh_token' do
       it 'renders a successful response' do
-        redis_instance = instance_double(Redis, get: "true")
+        redis_instance = instance_double(Redis, get: 'true')
         allow(UserJwtService).to receive(:redis).and_return(redis_instance)
-        post '/api/refresh', params: { authentication: {refresh_token: refresh_token}}
+        post '/api/refresh', params: { authentication: { refresh_token: refresh_token } }
         expect(response).to have_http_status(:unauthorized)
         expect(response.parsed_body['error']).to eq('Please Login')
       end
     end
 
     context 'with invalid token type' do
-      it 'renders a successful response' do
-        post '/api/refresh', params: { authentication: {refresh_token: token}}
+      it 'renders a unauthorized response' do
+        redis_instance = instance_double(Redis, get: nil, set: true)
+        allow(UserJwtService).to receive(:redis).and_return(redis_instance)
+        post '/api/refresh', params: { authentication: { refresh_token: token } }
         expect(response).to have_http_status(:unauthorized)
         expect(response.parsed_body['error']).to eq('Invalid token')
       end
@@ -73,6 +75,8 @@ RSpec.describe '/api/sign_in', type: :request do
   describe 'POST /sign_out' do
     context 'with valid email and password' do
       it 'renders a successful response' do
+        redis_instance = instance_double(Redis, get: nil, set: true)
+        allow(UserJwtService).to receive(:redis).and_return(redis_instance)
         post '/api/sign_out', headers: headers
         expect(response).to be_successful
         expect(response.parsed_body['data']['message']).to eq('Logout Success')
@@ -81,6 +85,8 @@ RSpec.describe '/api/sign_in', type: :request do
 
     context 'with invalid token header' do
       it 'renders a successful response' do
+        redis_instance = instance_double(Redis, get: nil, set: true)
+        allow(UserJwtService).to receive(:redis).and_return(redis_instance)
         post '/api/sign_out'
         expect(response).to have_http_status(:unauthorized)
         expect(response.parsed_body['error']).to eq('Please Login')

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -4,15 +4,20 @@ RSpec.describe '/api/sign_in', type: :request do
   let(:current_user) { create(:user, password: '123456') }
   let(:valid_params) { { authentication: { email: current_user.email, password: '123456' } } }
   let(:invalid_params) { { authentication: { email: current_user.email, password: '111111' } } }
-  let(:fake_token) { JwtService.encode({ user_id: current_user.id }) }
+  let(:token) { UserJwtService.generate_token(current_user.id) }
+  let(:expired_refresh_token) { JwtService.encode( { user_id: current_user.id, exp: 1.hour.ago.to_i } ) }
+  let(:refresh_token) { UserJwtService.generate_refresh_token(current_user.id) }
+  let(:headers) { { Authorization: "Bearer #{token}" } }
 
   describe 'POST /sign_in' do
     context 'with valid email and password' do
       it 'renders a successful response' do
-        allow(JwtService).to receive(:encode).and_return(fake_token)
+        allow(UserJwtService).to receive(:generate_token).and_return(token)
+        allow(UserJwtService).to receive(:generate_refresh_token).and_return(refresh_token)
         post '/api/sign_in', params: valid_params
         expect(response).to be_successful
-        expect(response.parsed_body['token']).to eq(fake_token)
+        expect(response.parsed_body['data']['token']).to eq(token)
+        expect(response.parsed_body['data']['refresh_token']).to eq(refresh_token)
       end
     end
 
@@ -21,6 +26,64 @@ RSpec.describe '/api/sign_in', type: :request do
         post '/api/sign_in', params: invalid_params
         expect(response).to have_http_status(:unauthorized)
         expect(response.parsed_body['error']).to eq('Invalid email or password')
+      end
+    end
+  end
+
+  describe 'POST /refresh' do
+    context 'with valid refresh_token' do
+      let (:new_token) { UserJwtService.generate_token(current_user.id) }
+      it 'renders a successful response' do
+        allow(UserJwtService).to receive(:decode).and_return({user_id: current_user.id, type: 'refesh_token'})
+        allow(UserJwtService).to receive(:generate_token).and_return(new_token)
+        post '/api/refresh', params: { authentication: {refresh_token: refresh_token}}
+        expect(response).to be_successful
+        expect(response.parsed_body['data']['token']).to eq(new_token)
+        expect(response.parsed_body['data']['refresh_token']).to eq(refresh_token)
+      end
+    end
+
+    context 'with expired refresh_token' do
+      it 'renders a successful response' do
+        post '/api/refresh', params: { authentication: {refresh_token: expired_refresh_token}}
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['error']).to eq('Please Login')
+      end
+    end
+
+    context 'with blocked refresh_token' do
+      it 'renders a successful response' do
+        redis_instance = instance_double(Redis, get: "true")
+        allow(UserJwtService).to receive(:redis).and_return(redis_instance)
+        post '/api/refresh', params: { authentication: {refresh_token: refresh_token}}
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['error']).to eq('Please Login')
+      end
+    end
+
+    context 'with invalid token type' do
+      it 'renders a successful response' do
+        post '/api/refresh', params: { authentication: {refresh_token: token}}
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['error']).to eq('Invalid token')
+      end
+    end
+  end
+
+  describe 'POST /sign_out' do
+    context 'with valid email and password' do
+      it 'renders a successful response' do
+        post '/api/sign_out', headers: headers
+        expect(response).to be_successful
+        expect(response.parsed_body['data']['message']).to eq('Logout Success')
+      end
+    end
+
+    context 'with invalid token header' do
+      it 'renders a successful response' do
+        post '/api/sign_out'
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['error']).to eq('Please Login')
       end
     end
   end

--- a/spec/requests/api/v1/keywords_spec.rb
+++ b/spec/requests/api/v1/keywords_spec.rb
@@ -5,12 +5,17 @@ RSpec.describe '/api/v1/keywords', type: :request do
   let(:token) { UserJwtService.generate_token(current_user.id) }
   let(:headers) { { Authorization: "Bearer #{token}" } }
 
+  before(:each) do
+    redis_instance = instance_double(Redis, get: nil, set: true)
+    allow(UserJwtService).to receive(:redis).and_return(redis_instance)
+  end
+
   describe 'GET /index' do
     let!(:keyword) { create(:keyword) }
     let!(:user_keyword) { create(:user_keyword, user: current_user, keyword: keyword) }
-
     context 'without params search' do
       it 'renders a successful response' do
+        allow(UserJwtService).to receive(:decode).and_return({ user_id: current_user.id })
         get '/api/v1/keywords', headers: headers
         expect(response).to be_successful
         expect(response.parsed_body['data'].count).to eq(1)

--- a/spec/requests/api/v1/keywords_spec.rb
+++ b/spec/requests/api/v1/keywords_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe '/api/v1/keywords', type: :request do
   let(:current_user) { create(:user) }
-  let(:token) { JwtService.encode({ user_id: current_user.id }) }
+  let(:token) { UserJwtService.generate_token(current_user.id) }
   let(:headers) { { Authorization: "Bearer #{token}" } }
 
   describe 'GET /index' do

--- a/spec/routing/api/v1/authentication_routing_spec.rb
+++ b/spec/routing/api/v1/authentication_routing_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Api::AuthenticationController, type: :routing do
+  describe 'routing' do
+    it 'routes to #sign_in' do
+      expect(post: '/api/sign_in').to route_to('api/authentication#sign_in')
+    end
+
+    it 'routes to #refresh' do
+      expect(post: '/api/refresh').to route_to('api/authentication#refresh')
+    end
+
+    it 'routes to #sign_out' do
+      expect(post: '/api/sign_out').to route_to('api/authentication#sign_out')
+    end
+  end
+end

--- a/spec/routing/api/v1/keywords_routing_spec.rb
+++ b/spec/routing/api/v1/keywords_routing_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::KeywordsController, type: :routing do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/api/v1/keywords').to route_to('api/v1/keywords#index')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/api/v1/keywords/1').to route_to('api/v1/keywords#show', id: '1')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/api/v1/keywords').to route_to('api/v1/keywords#create')
+    end
+  end
+end

--- a/spec/services/user_jwt_service_spec.rb
+++ b/spec/services/user_jwt_service_spec.rb
@@ -1,0 +1,58 @@
+# spec/services/user_jwt_service_spec.rb
+require 'rails_helper'
+
+RSpec.describe UserJwtService, type: :service do
+  let(:user_id) { 1 }
+  let(:token) { described_class.generate_token(user_id) }
+  let(:refresh_token) { described_class.generate_refresh_token(user_id) }
+
+  describe '.generate_token' do
+    it 'generates a JWT token' do
+      result = described_class.generate_token(user_id)
+      expect(result).to be_a(String)
+    end
+  end
+
+  describe '.generate_refresh_token' do
+    it 'generates a refresh token' do
+      result = described_class.generate_refresh_token(user_id)
+      expect(result).to be_a(String)
+    end
+  end
+
+  describe '.decode' do
+     context 'with a valid token' do
+      it 'decodes a JWT token and returns the payload' do
+        redis_instance = instance_double(Redis, get: nil)
+        allow(UserJwtService).to receive(:redis).and_return(redis_instance)
+
+        result = described_class.decode(token)
+        expect(result).to include('user_id' => user_id)
+      end
+    end
+
+    context 'with a blocked token' do
+      it 'raises JWTRejectedError' do
+        redis_instance = instance_double(Redis, get: "true")
+        allow(UserJwtService).to receive(:redis).and_return(redis_instance)
+        expect { described_class.decode(token) }.to raise_error(UserJwtService::JwtRejectedError, 'Token invalid')
+      end
+    end
+
+    context 'with a invalid token type' do
+      it 'decodes a JWT token and returns the payload' do
+        expect { described_class.decode(token, type: "refresh_token") }.to raise_error(UserJwtService::JwtTypeError, 'Token type invalid')
+      end
+    end
+  end
+
+  describe '.block' do
+    it 'blocks a token' do
+      redis_instance = instance_double(Redis, set: true)
+      payload = JwtService.decode(token)
+      allow(UserJwtService).to receive(:redis).and_return(redis_instance)
+      result = described_class.block(token, payload)
+      expect(result).to eq(true)
+    end
+  end
+end

--- a/spec/services/user_jwt_service_spec.rb
+++ b/spec/services/user_jwt_service_spec.rb
@@ -21,11 +21,10 @@ RSpec.describe UserJwtService, type: :service do
   end
 
   describe '.decode' do
-     context 'with a valid token' do
+    context 'with a valid token' do
       it 'decodes a JWT token and returns the payload' do
         redis_instance = instance_double(Redis, get: nil)
         allow(UserJwtService).to receive(:redis).and_return(redis_instance)
-
         result = described_class.decode(token)
         expect(result).to include('user_id' => user_id)
       end
@@ -33,7 +32,7 @@ RSpec.describe UserJwtService, type: :service do
 
     context 'with a blocked token' do
       it 'raises JWTRejectedError' do
-        redis_instance = instance_double(Redis, get: "true")
+        redis_instance = instance_double(Redis, get: 'true')
         allow(UserJwtService).to receive(:redis).and_return(redis_instance)
         expect { described_class.decode(token) }.to raise_error(UserJwtService::JwtRejectedError, 'Token invalid')
       end
@@ -41,7 +40,9 @@ RSpec.describe UserJwtService, type: :service do
 
     context 'with a invalid token type' do
       it 'decodes a JWT token and returns the payload' do
-        expect { described_class.decode(token, type: "refresh_token") }.to raise_error(UserJwtService::JwtTypeError, 'Token type invalid')
+        redis_instance = instance_double(Redis, get: nil)
+        allow(UserJwtService).to receive(:redis).and_return(redis_instance)
+        expect { described_class.decode(token, type: 'refresh_token') }.to raise_error(UserJwtService::JwtTypeError, 'Token type invalid')
       end
     end
   end


### PR DESCRIPTION
# contents

  - [x] endpoint POST api/refresh
  - [x] endpoint POST api/sign_out
  - [x] expired time of jwt: 15 mins
  - [x] expired time of refresh token: 7 days
  - [x] add refresh token to api/login response and cover with payload: data: {}
  - [x] add block jwt with sign_out or block request from jwt


# Routes

```
                             api_refresh POST   /api/refresh(.:format)                                                                            api/authentication#refresh
                            api_sign_out POST   /api/sign_out(.:format)      
```